### PR TITLE
fix build failure with nixos libfuse3 headers

### DIFF
--- a/cuse-lowlevel/build.rs
+++ b/cuse-lowlevel/build.rs
@@ -23,7 +23,8 @@ fn fuse_binding_filter(builder: bindgen::Builder) -> bindgen::Builder {
         .allowlist_function("(?i)^fuse.*")
         .allowlist_var("(?i)^fuse.*")
         .blocklist_type("fuse_log_func_t")
-        .blocklist_function("fuse_set_log_func");
+        .blocklist_function("fuse_set_log_func")
+        .allowlist_type("^libfuse_version$");
     builder
 }
 


### PR DESCRIPTION
It pulls in a define that references libfuse_version, which is currently blacklisted

Fixes the following cargo build error:
```
error[E0425]: cannot find type `libfuse_version` in this scope
```


